### PR TITLE
Remove travis link in getting-started once and for all

### DIFF
--- a/getting-started/readme.dev.md
+++ b/getting-started/readme.dev.md
@@ -1,4 +1,4 @@
-### Spinning Square [![Build Status](https://travis-ci.org/TyOverby/Piston-Tutorial.svg?branch=master)](https://travis-ci.org/TyOverby/Piston-Tutorial)
+### Spinning Square
 
 In this tutorial, I hope to get you from an empty Cargo project to having a
 window with a rotating square in it.

--- a/getting-started/readme.md
+++ b/getting-started/readme.md
@@ -1,4 +1,4 @@
-### Spinning Square [![Build Status](https://travis-ci.org/PistonDevelopers/Piston-Tutorials.svg?branch=master)](https://travis-ci.org/PistonDevelopers/Piston-Tutorials)
+### Spinning Square
 
 In this tutorial, I hope to get you from an empty Cargo project to having a
 window with a rotating square in it.


### PR DESCRIPTION
The travis badge will only be in the top level Readme.
