### PR TITLE
Update names of the dependencies.

### DIFF
--- a/getting-started/Cargo.toml
+++ b/getting-started/Cargo.toml
@@ -15,14 +15,14 @@ name = "game"
 
 git = "https://github.com/PistonDevelopers/piston.git"
 
-[dependencies.sdl2_window]
+[dependencies.pistoncore-sdl2_window]
 
 git = "https://github.com/PistonDevelopers/sdl2_window.git"
 
-[dependencies.graphics]
+[dependencies.piston2d-graphics]
 
 git = "https://github.com/PistonDevelopers/graphics.git"
 
-[dependencies.opengl_graphics]
+[dependencies.piston2d-opengl_graphics]
 
 git = "https://github.com/PistonDevelopers/opengl_graphics.git"

--- a/getting-started/readme.md
+++ b/getting-started/readme.md
@@ -92,15 +92,15 @@ name = "game"
 
 git = "https://github.com/PistonDevelopers/piston.git"
 
-[dependencies.sdl2_window]
+[dependencies.pistoncore-sdl2_window]
 
 git = "https://github.com/PistonDevelopers/sdl2_window.git"
 
-[dependencies.graphics]
+[dependencies.piston2d-graphics]
 
 git = "https://github.com/PistonDevelopers/graphics.git"
 
-[dependencies.opengl_graphics]
+[dependencies.piston2d-opengl_graphics]
 
 git = "https://github.com/PistonDevelopers/opengl_graphics.git"
 


### PR DESCRIPTION
Updates the names of the dependencies to new naming.

It still does not compile. There seems to be some incompatibilities (as also discussed in PistonDevelopers/piston#772
