### PR TITLE
Update the getting-started to the new graphics library.

### DIFF
--- a/getting-started/src/main.rs
+++ b/getting-started/src/main.rs
@@ -7,7 +7,7 @@ extern crate event;
 
 use sdl2_window::Sdl2Window;
 use opengl_graphics::Gl;
-use shader_version::opengl::OpenGL::OpenGL_3_2;
+use shader_version::opengl::OpenGL::_3_2;
 
 use std::cell::RefCell;
 use piston::{
@@ -17,9 +17,7 @@ use piston::{
 
 use graphics::{
     Context,
-    AddRectangle,
-    AddColor,
-    Draw,
+    Rectangle,
     RelativeTransform,
 };
 
@@ -39,17 +37,14 @@ impl App {
     fn render<W: Window>(&mut self, _: &mut W, args: &RenderArgs) {
         // Set up a context to draw into.
         let context = &Context::abs(args.width as f64, args.height as f64);
-        // Clear the screen.
-        context.rgba(0.0,1.0,0.0,1.0).draw(&mut self.gl);
+        // Clear the screen
+        graphics::clear([0.0,1.0,0.0,1.0], &mut self.gl);
 
         // Draw a box rotating around the middle of the screen.
-        context
-            .trans((args.width / 2) as f64, (args.height / 2) as f64)
+        let center_context = &context.trans((args.width / 2) as f64, (args.height / 2) as f64)
             .rot_rad(self.rotation)
-            .rect(0.0, 0.0, 50.0, 50.0)
-            .rgba(1.0, 0.0, 0.0,1.0)
-            .trans(-25.0, -25.0)
-            .draw(&mut self.gl);
+            .trans(-25.0, -25.0);
+        Rectangle::new([1.0, 0.0, 0.0, 1.0]).draw([0.0, 0.0, 50.0, 50.0], center_context, &mut self.gl);
     }
 
     fn update<W: Window>(&mut self, _: &mut W, args: &UpdateArgs) {
@@ -61,12 +56,12 @@ impl App {
 fn main() {
     // Create an SDL window.
     let window = Sdl2Window::new(
-        OpenGL_3_2,
+        _3_2,
         piston::WindowSettings::default()
-    );
+            );
 
     // Create a new game and run it.
-    let mut app = App { gl: Gl::new(OpenGL_3_2), rotation: 0.0 };
+    let mut app = App { gl: Gl::new(_3_2), rotation: 0.0 };
 
     let window = RefCell::new(window);
     for e in Events::new(&window) {


### PR DESCRIPTION
This fixes the code and makes it show the rotating box again.

But one question and one problem remain:
1. Is there still a `clear` function that clears the screen in the new graphics library? I couldn't find the equivalent in the new design.
2. I couldn't recreate the document (running `cargo run` from the root of the project) because of errors in the dependencies. I, however, have no idea how to fix them. Could someone take a look at it?
