### PR TITLE
Need to install freetype headers on Ubuntu

### DIFF
--- a/getting-started/readme.md
+++ b/getting-started/readme.md
@@ -48,7 +48,7 @@ homebrew instructions.
 
 ### SDL2 on Ubuntu
 If you are on Ubuntu Trusty, you can run
-`sudo apt-get install libsdl2-dev`!
+`sudo apt-get install libsdl2-dev libfreetype6-dev`!
 
 ### SDL2 on Linux
 Follow the instructions found [here](http://nothingtocode.blogspot.com/2013/07/setting-up-sdl2-in-ubuntu-or-linux-mint.html).


### PR DESCRIPTION
PR to update the Ubuntu instructions to account for #40 : I got a message about missing freetype headers when I tried to compile on my lubuntu development vm, and installing libfreetype6-dev fixed it.

As mentioned in that issue, maybe the correct fix here is to figure out what introduced the hard dependency on freetype-rs (which is presumably what depends on the freetype headers) and remove that instead?

Since PR #46 included instructions for freetype on windows I figured I'd raise this anyway.