### PR TITLE
Updated readme to include installation of freetype on OSX Yosemite

### DIFF
--- a/getting-started/readme.md
+++ b/getting-started/readme.md
@@ -36,7 +36,9 @@ either GLFW or SDL2 as the implementation of the windowing system.
 The rest of this tutorial uses SDL2 for windowing, so we will need to
 install the SDL2 native library.
 
-### SDL2 on OSX
+### SDL2
+
+#### SDL2 on OSX
 
 If you use [Homebrew](http://brew.sh), installing sdl2 is as simple as
 `brew install sdl2`. That's it. Done.
@@ -46,17 +48,17 @@ Otherwise, follow the steps under [sdl2 on Linux](#sdl2-on-linux).
 Honestly, it's probably easier to just install Homebrew and then follow the
 homebrew instructions.
 
-### SDL2 on Ubuntu
+#### SDL2 on Ubuntu
 If you are on Ubuntu Trusty, you can run
 `sudo apt-get install libsdl2-dev libfreetype6-dev`!
 
-### SDL2 on Linux
+#### SDL2 on Linux
 Follow the instructions found [here](http://nothingtocode.blogspot.com/2013/07/setting-up-sdl2-in-ubuntu-or-linux-mint.html).
 
-#### At this stage
+##### At this stage
 `ldconfig -p | grep libSDL2` should print out some paths to the .so libraries.
 
-### SDL2 on Windows
+#### SDL2 on Windows
 Copy `SDL2.dll` to the project directory root (where your `Cargo.toml` is, see below).
 You will need to distribute this file alongside your `.exe`.
 - For 32-bit Windows, download [this SDL2.dll](https://github.com/tedsta/getting-started-with-piston/blob/master/windows_clibs/i686/SDL2.dll?raw=true).
@@ -65,6 +67,9 @@ You will need to distribute this file alongside your `.exe`.
 Copy `libSDL2.dll.a` and `libfreetype-6.a` to `$RUST_ROOT\bin\rustlib\$CPU_ARCH-pc-windows-gnu\lib`.
 - For 32-bit Windows, download [this libSDL2.dll.a](https://github.com/tedsta/getting-started-with-piston/blob/master/windows_clibs/i686/libSDL2.dll.a?raw=true) and [this libfreetype-6.a](https://github.com/tedsta/getting-started-with-piston/blob/master/windows_clibs/i686/libfreetype-6.a?raw=true) to e.g. `C:\Rust\bin\rustlib\i686-pc-windows-gnu\lib\`.
 - For 64-bit Windows, download [that libSDL2.dll.a](https://github.com/tedsta/getting-started-with-piston/blob/master/windows_clibs/x86_64/libSDL2.dll.a?raw=true) and [that libfreetype-6.a](https://github.com/tedsta/getting-started-with-piston/blob/master/windows_clibs/x86_64/libfreetype-6.a?raw=true) to e.g. `C:\Rust\bin\rustlib\x86_64-pc-windows-gnu\lib\`.
+
+### Freetype on OSX
+On Yosemite, you will also need to install freetype. The easiest way is to use [Homebrew](http://brew.sh), as above, using `brew install freetype`.
 
 ## Setting Up The Project
 


### PR DESCRIPTION
Installation requires freetype on OSX Yosemite, and it's not immediately obvious, so it would be nice to have instructions telling users where to get it.