### PR TITLE
Update dependencies in the project to use the newest version of opengl_graphics.

### DIFF
--- a/getting-started/Cargo.toml
+++ b/getting-started/Cargo.toml
@@ -12,6 +12,6 @@ name = "spinning-square"
 
 [dependencies]
 piston = "0.2.2"
-piston2d-graphics = "0.1.4"
+piston2d-graphics = "0.2.0"
 pistoncore-glutin_window = "0.3.0"
-piston2d-opengl_graphics = "0.1.0"
+piston2d-opengl_graphics = "0.2.0"


### PR DESCRIPTION
With the last changes that @bvssvni made to opengl_graphics so that it uses a newer version of 2dgraphics I was able to build and run with the newest set of dependencies.