### PR TITLE
Correct the version numbers of dependencies

### DIFF
--- a/getting-started/readme.md
+++ b/getting-started/readme.md
@@ -83,8 +83,8 @@ name = "spinning-square"
 
 [dependencies]
 piston = "0.4.1"
-piston2d-graphics = "0.5.0"
-pistoncore-glutin_window = "0.4.1"
+piston2d-graphics = "0.4.1"
+pistoncore-glutin_window = "0.5.0"
 piston2d-opengl_graphics = "0.6.0"
 ```
 


### PR DESCRIPTION
I'm pretty certain that these version numbers are the wrong way round. On build, I had to reverse the two in order to compile.