### PR TITLE
Updated with `cargo run`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,9 @@ authors = [
 ]
 
 [dependencies.md_rel]
-git = "https://github.com/TyOverby/md_rel.git"
+#git = "https://github.com/TyOverby/md_rel.git"
+#Use the one above when https://github.com/TyOverby/md_rel/pull/7 is merged.
+git = "https://github.com/bvssvni/md_rel.git"
 
 [[bin]]
 name = "markdown_compiler"

--- a/getting-started/readme.dev.md
+++ b/getting-started/readme.dev.md
@@ -33,8 +33,8 @@ Parts of the Piston project depend on native C libraries. For example, in
 order to display a window and hook it up to an OpenGL context, we can use
 either Glutin, GLFW or SDL2 as the implementation of the windowing system.
 
-The rest of this tutorial uses SDL2 for windowing, so we will need to
-install the SDL2 native library.
+The rest of this tutorial uses Glutin for windowing, so we won't need to
+directly install any additional libraries for that purpose.
 
 ### Freetype on OS X
 

--- a/getting-started/readme.md
+++ b/getting-started/readme.md
@@ -84,8 +84,9 @@ name = "spinning-square"
 [dependencies]
 piston = "0.4.1"
 piston2d-graphics = "0.4.1"
-pistoncore-glutin_window = "0.5.0"
+pistoncore-glutin_window = "0.6.0"
 piston2d-opengl_graphics = "0.6.0"
+
 ```
 
 You might be thinking that this is a lot of dependencies for such a simple
@@ -153,7 +154,8 @@ impl App {
 
         let square = rectangle::square(0.0, 0.0, 50.0);
         let rotation = self.rotation;
-        let (x, y) = ((args.width / 2) as f64, (args.height / 2) as f64);
+        let (x, y) = ((args.draw_width / 2) as f64,
+                      (args.draw_height / 2) as f64);
 
         self.gl.draw(args.viewport(), |c, gl| {
             // Clear the screen.
@@ -203,6 +205,7 @@ fn main() {
         }
     }
 }
+
 ```
 
 ## Compiling And Running


### PR DESCRIPTION
Closes https://github.com/PistonDevelopers/Piston-Tutorials/issues/83

Needs https://github.com/TyOverby/md_rel/pull/7 to work, so overriding
my fork temporarily.

* md_rel inserts `rust` when `toml` is used, so I editing this manually.