### PR TITLE
Box only spins in bottom right corner

### DIFF
--- a/getting-started/src/main.rs
+++ b/getting-started/src/main.rs
@@ -22,8 +22,8 @@ impl App {
 
         let square = rectangle::square(0.0, 0.0, 50.0);
         let rotation = self.rotation;
-        let (x, y) = ((args.draw_width / 2) as f64,
-                      (args.draw_height / 2) as f64);
+        let (x, y) = ((args.draw_width / 4) as f64,
+                      (args.draw_height / 4) as f64);
 
         self.gl.draw(args.viewport(), |c, gl| {
             // Clear the screen.


### PR DESCRIPTION
Did the tutorial today, when I compiled on the stable version of rust the box only spun in the bottom right hand corner. Dividing by four instead of two fixed it so that the box actually spins in the middle.