### PR TITLE
update sudoku tutorial to use cargo-edit

### DIFF
--- a/sudoku/README.md
+++ b/sudoku/README.md
@@ -44,8 +44,8 @@ hi
 If this is not working, you might have forgotten the `--bin` flag after `cargo new`. Delete the folder and try again.
 
 Now, we need to add a few libraries to the Cargo.toml.
-To make this more efficient, we will install the tool `cargo-add` such that we can type `cargo add <package>`.
-To install `cargo-add`, type the following:
+To make this more efficient, we will install the tool `cargo-edit` such that we can type `cargo add <package>`.
+To install `cargo-edit`, type the following:
 
 ```
 cargo install cargo-edit

--- a/sudoku/README.md
+++ b/sudoku/README.md
@@ -48,7 +48,7 @@ To make this more efficient, we will install the tool `cargo-add` such that we c
 To install `cargo-add`, type the following:
 
 ```
-cargo install cargo-add
+cargo install cargo-edit
 ```
 
 The first library we will add is `piston`.


### PR DESCRIPTION
Cargo-add has been deprecated in favor of cargo-edit (see their repo https://github.com/withoutboats/cargo-add). All existing `cargo add` commands in the tutorial still work with cargo-edit.