### PR TITLE
Fix errors when building

### DIFF
--- a/sudoku/chp-03.md
+++ b/sudoku/chp-03.md
@@ -58,7 +58,7 @@ Add a setting that tells the window backend which OpenGL version to use:
 ```rust
   let opengl = OpenGL::V3_2;
   let settings = WindowSettings::new("Sudoku", [512; 2])
-      .opengl(opengl)
+      .graphic_api(opengl)
       .exit_on_esc(true);
 ```
 

--- a/sudoku/chp-04.md
+++ b/sudoku/chp-04.md
@@ -108,7 +108,7 @@ Add the following code:
 use graphics::types::Color;
 use graphics::{Context, Graphics};
 
-use GameboardController;
+use crate::gameboard_controller::GameboardController;
 
 /// Stores gameboard view settings.
 pub struct GameboardViewSettings {


### PR DESCRIPTION
It seems one API is changed from `opengl` to `graphic_api` in WindowsSetting.