### PR TITLE
Prefer specific imports over glob ones in "Getting started" tutorial

### DIFF
--- a/getting-started/src/main.rs
+++ b/getting-started/src/main.rs
@@ -4,10 +4,10 @@ extern crate glutin_window;
 extern crate opengl_graphics;
 
 use piston::window::WindowSettings;
-use piston::event_loop::*;
-use piston::input::*;
+use piston::event_loop::{EventSettings, Events};
+use piston::input::{RenderArgs, RenderEvent, UpdateArgs, UpdateEvent};
 use glutin_window::GlutinWindow as Window;
-use opengl_graphics::{ GlGraphics, OpenGL };
+use opengl_graphics::{GlGraphics, OpenGL};
 
 pub struct App {
     gl: GlGraphics, // OpenGL drawing backend.

--- a/getting-started/src/main.rs
+++ b/getting-started/src/main.rs
@@ -1,17 +1,17 @@
-extern crate piston;
-extern crate graphics;
 extern crate glutin_window;
+extern crate graphics;
 extern crate opengl_graphics;
+extern crate piston;
 
-use piston::window::WindowSettings;
-use piston::event_loop::{EventSettings, Events};
-use piston::input::{RenderArgs, RenderEvent, UpdateArgs, UpdateEvent};
 use glutin_window::GlutinWindow as Window;
 use opengl_graphics::{GlGraphics, OpenGL};
+use piston::event_loop::{EventSettings, Events};
+use piston::input::{RenderArgs, RenderEvent, UpdateArgs, UpdateEvent};
+use piston::window::WindowSettings;
 
 pub struct App {
     gl: GlGraphics, // OpenGL drawing backend.
-    rotation: f64   // Rotation for the square.
+    rotation: f64,  // Rotation for the square.
 }
 
 impl App {
@@ -19,20 +19,21 @@ impl App {
         use graphics::*;
 
         const GREEN: [f32; 4] = [0.0, 1.0, 0.0, 1.0];
-        const RED:   [f32; 4] = [1.0, 0.0, 0.0, 1.0];
+        const RED: [f32; 4] = [1.0, 0.0, 0.0, 1.0];
 
         let square = rectangle::square(0.0, 0.0, 50.0);
         let rotation = self.rotation;
-        let (x, y) = (args.window_size[0] / 2.0,
-                      args.window_size[1] / 2.0);
+        let (x, y) = (args.window_size[0] / 2.0, args.window_size[1] / 2.0);
 
         self.gl.draw(args.viewport(), |c, gl| {
             // Clear the screen.
             clear(GREEN, gl);
 
-            let transform = c.transform.trans(x, y)
-                                       .rot_rad(rotation)
-                                       .trans(-25.0, -25.0);
+            let transform = c
+                .transform
+                .trans(x, y)
+                .rot_rad(rotation)
+                .trans(-25.0, -25.0);
 
             // Draw a box rotating around the middle of the screen.
             rectangle(RED, square, transform, gl);
@@ -50,10 +51,7 @@ fn main() {
     let opengl = OpenGL::V3_2;
 
     // Create an Glutin window.
-    let mut window: Window = WindowSettings::new(
-            "spinning-square",
-            [200, 200]
-        )
+    let mut window: Window = WindowSettings::new("spinning-square", [200, 200])
         .graphics_api(opengl)
         .exit_on_esc(true)
         .build()
@@ -62,17 +60,17 @@ fn main() {
     // Create a new game and run it.
     let mut app = App {
         gl: GlGraphics::new(opengl),
-        rotation: 0.0
+        rotation: 0.0,
     };
 
     let mut events = Events::new(EventSettings::new());
     while let Some(e) = events.next(&mut window) {
-        if let Some(r) = e.render_args() {
-            app.render(&r);
+        if let Some(args) = e.render_args() {
+            app.render(&args);
         }
 
-        if let Some(u) = e.update_args() {
-            app.update(&u);
+        if let Some(args) = e.update_args() {
+            app.update(&args);
         }
     }
 }


### PR DESCRIPTION
As suggested in #202, glob imports don't fit into the tutorial because they don't show where does a specific type come from. This simple PR fixes this issue and also formats code with `rustfmt` to make it prettier.