### PR TITLE
Fixes #225 (multiple digits) issue.

### DIFF
--- a/sudoku/chp-06.md
+++ b/sudoku/chp-06.md
@@ -146,6 +146,12 @@ Draw characters after drawing selected cell background:
                 if let Ok(character) = glyphs.character(34, ch) {
                     let ch_x = pos[0] + character.left();
                     let ch_y = pos[1] - character.top();
+                    let text_image = text_image.src_rect([
+                        character.atlas_offset[0],
+                        character.atlas_offset[1],
+                        character.atlas_size[0],
+                        character.atlas_size[1],
+                    ]);
                     text_image.draw(character.texture,
                                     &c.draw_state,
                                     c.transform.trans(ch_x, ch_y),


### PR DESCRIPTION
The problem identified in #225 is that the entire rendered font texture is being rendered in each cell instead of just the part with the desired digit.

If you look at what the implementation of `Text` does, you will see, it [renders a sub rect](https://github.com/PistonDevelopers/graphics/blob/4b4e7975c97e7098f7d5a3e759ce7beadabe9039/src/text.rs#L60-L74) of the character texture when drawing a character.

This PR applies the same technique to only draw a single character in each cell.