### PR TITLE
Fix no method named `graphic_api` found for type `piston::WindowSettings` in the current scope

### DIFF
--- a/sudoku/chp-03.md
+++ b/sudoku/chp-03.md
@@ -58,7 +58,7 @@ Add a setting that tells the window backend which OpenGL version to use:
 ```rust
   let opengl = OpenGL::V3_2;
   let settings = WindowSettings::new("Sudoku", [512; 2])
-      .graphic_api(opengl)
+      .graphics_api(opengl)
       .exit_on_esc(true);
 ```
 


### PR DESCRIPTION
Update `graphic_api` to `graphics_api` in chp-03.md. 
`graphic_api` doesn't appear to be available on piston::window::WindowSettings