### PR TITLE
fix `sudoku` compile error

### DIFF
--- a/sudoku/Cargo.toml
+++ b/sudoku/Cargo.toml
@@ -6,7 +6,7 @@ version = "0.1.0"
 name = "sudoku"
 
 [dependencies]
-piston = "*"
-piston2d-graphics = "*"
-piston2d-opengl_graphics = "*"
-pistoncore-glutin_window = "*"
+piston = "0.52.0"
+piston2d-graphics = "0.37.0"
+pistoncore-glutin_window = "0.66.0"
+piston2d-opengl_graphics = "0.74.0"

--- a/sudoku/src/main.rs
+++ b/sudoku/src/main.rs
@@ -24,7 +24,7 @@ mod gameboard_view;
 fn main() {
     let opengl = OpenGL::V3_2;
     let settings = WindowSettings::new("Sudoku", [512; 2])
-        .opengl(opengl)
+        .graphics_api(opengl)
         .exit_on_esc(true);
     let mut window: GlutinWindow = settings.build()
         .expect("Could not create window");


### PR DESCRIPTION
The current sudoku compile will get an error:  
```
error[E0311]: the parameter type `K` may not live long enough
   --> /home/hustccc/.cargo/registry/src/mirrors.tuna.tsinghua.edu.cn-df7c3c540f42cdbd/rusttype-0.2.3/src/support/bst/map.rs:81:19
    |
81  |             match node.force() {
    |                   ^^^^
    |
    = help: consider adding an explicit lifetime bound for `K`
note: the parameter type `K` must be valid for the anonymous lifetime #1 defined on the function body at 77:9...
   --> /home/hustccc/.cargo/registry/src/mirrors.tuna.tsinghua.edu.cn-df7c3c540f42cdbd/rusttype-0.2.3/src/support/bst/map.rs:77:9
    |
77  | /         fn clone_subtree<K: Clone, V: Clone>(
78  | |                 node: node::NodeRef<marker::Immut, K, V, marker::LeafOrInternal>)
79  | |                 -> BTreeMap<K, V> {
80  | |
...   |
136 | |             }
137 | |         }
    | |_________^
error: could not compile `rusttype`.
```
Because the `piston2d-graphics`  crate depends on the `rusttype-0.2.3` crate, however the `rusttype-0.2.3` can not compiles successfully.  
And this PR will fix it by specifying the right version of `piston2d-graphics` like `getting-start` tutorial.  
Also this PR fix an error in src/main.rs, which locates in line 27.  